### PR TITLE
Update OptimistAllowlist.sol

### DIFF
--- a/src/op-nft/OptimistAllowlist.sol
+++ b/src/op-nft/OptimistAllowlist.sol
@@ -75,7 +75,7 @@ contract OptimistAllowlist is ISemver {
     /// @return allowed_ Whether or not the address is allowed to mint yet.
     function isAllowedToMint(address _claimer) public view returns (bool allowed_) {
         allowed_ = _hasAttestationFromAllowlistAttestor(_claimer) || _hasAttestationFromCoinbaseQuestAttestor(_claimer)
-            || _hasAttestationFromOptimistInviter(_claimer);
+            || _hasAttestationFromOptimistInviter(_claimer) || _hasEasOptimistAllowlistAttestation(_claimer);
     }
 
     /// @notice Checks whether an address has a valid 'optimist.can-mint' attestation from the

--- a/src/op-nft/OptimistAllowlist.sol
+++ b/src/op-nft/OptimistAllowlist.sol
@@ -5,6 +5,7 @@ import {ISemver} from "eas-contracts/ISemver.sol";
 
 import "./AttestationStation.sol";
 import "./OptimistConstants.sol";
+import "../OptimistAllowlistAttestationResolver.sol";
 
 /// @title  OptimistAllowlist
 /// @notice Source of truth for whether an address is able to mint an Optimist NFT.
@@ -34,24 +35,32 @@ contract OptimistAllowlist is ISemver {
     ///         attestations.
     address public immutable OPTIMIST_INVITER;
 
+    /// @notice Address of OptimistAllowlistAttestationResolver contract that indexes EAS allowlist attestations
+    ///         attestations.
+    OptimistAllowlistAttestationResolver public immutable EAS_OPTIMIST_ALLOWLIST_ATTESTATION_RESOLVER;
+
     /// @notice Semantic version.
-    /// @custom:semver 1.1.0
-    string public constant version = "1.1.0";
+    /// @custom:semver 1.2.0
+    string public constant version = "1.2.0";
 
     /// @param _attestationStation    Address of the AttestationStation contract.
     /// @param _allowlistAttestor     Address of the allowlist attestor.
     /// @param _coinbaseQuestAttestor Address of the Coinbase Quest attestor.
     /// @param _optimistInviter       Address of the OptimistInviter contract.
+    /// @param _easOptimistAllowlistAttestationResolver       Address of the EAS attestation resolver.
+
     constructor(
         AttestationStation _attestationStation,
         address _allowlistAttestor,
         address _coinbaseQuestAttestor,
-        address _optimistInviter
+        address _optimistInviter,
+        OptimistAllowlistAttestationResolver _easOptimistAllowlistAttestationResolver
     ) {
         ATTESTATION_STATION = _attestationStation;
         ALLOWLIST_ATTESTOR = _allowlistAttestor;
         COINBASE_QUEST_ATTESTOR = _coinbaseQuestAttestor;
         OPTIMIST_INVITER = _optimistInviter;
+        EAS_OPTIMIST_ALLOWLIST_ATTESTATION_RESOLVER = _easOptimistAllowlistAttestationResolver;
     }
 
     /// @notice Checks whether a given address is allowed to mint the Optimist NFT yet. Since the
@@ -96,6 +105,11 @@ contract OptimistAllowlist is ISemver {
         );
     }
 
+    // TODO add natspect
+    function _hasEasOptimistAllowlistAttestation(address _claimer) internal view returns (bool valid_) {
+        valid_ = EAS_OPTIMIST_ALLOWLIST_ATTESTATION_RESOLVER.hasAttestation(_claimer);
+    }
+
     /// @notice Checks whether an address has a valid truthy attestation.
     ///         Any attestation val other than bytes32("") is considered truthy.
     /// @param _creator Address that made the attestation.
@@ -105,4 +119,5 @@ contract OptimistAllowlist is ISemver {
     function _hasValidAttestation(address _creator, address _about, bytes32 _key) internal view returns (bool valid_) {
         valid_ = ATTESTATION_STATION.attestations(_creator, _about, _key).length > 0;
     }
+
 }


### PR DESCRIPTION
Instead of checking the resolver state directly from the Optimist contract, we should update the OptimistAllowlist contract. The OptimistAllowlist contract is deployed behind a proxy so it is upgradeable. It doesn't have an initialize function because it is stateless.